### PR TITLE
Fix bad .mer extension pattern in file pickers

### DIFF
--- a/SaturnEdit/Windows/Main/ChartEditor/ChartEditorView.axaml.cs
+++ b/SaturnEdit/Windows/Main/ChartEditor/ChartEditorView.axaml.cs
@@ -147,7 +147,7 @@ public partial class ChartEditorView : UserControl
                 [
                     new("Chart Files")
                     {
-                        Patterns = ["*.sat", "*.mer*", "*.map"],
+                        Patterns = ["*.sat", "*.mer", "*.map"],
                     },
                 ],
             });
@@ -281,7 +281,7 @@ public partial class ChartEditorView : UserControl
                 [
                     new("Chart Files")
                     {
-                        Patterns = ["*.sat", "*.mer*", "*.map"],
+                        Patterns = ["*.sat", "*.mer", "*.map"],
                     },
                 ],
             });


### PR DESCRIPTION
This should fix picking .mer files under MacOS.