### PR TITLE
Implement rudimentary launch argument handler as LaunchSystem and auto open chart by argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 /.idea
+/.vs

--- a/SaturnEdit/App.axaml.cs
+++ b/SaturnEdit/App.axaml.cs
@@ -18,6 +18,7 @@ public partial class App : Application
         LoggingSystem.Initialize();
         SoftwareUpdateSystem.Initialize();
         AutosaveSystem.Initialize();
+        LaunchSystem.Initialize();
         SettingsSystem.Initialize();
         SoundpackSystem.Initialize();
         TimeSystem.Initialize();

--- a/SaturnEdit/Program.cs
+++ b/SaturnEdit/Program.cs
@@ -9,9 +9,13 @@ class Program
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
+    public static string[] LaunchArguments { get; set; }
+
     [STAThread]
     public static void Main(string[] args)
     {
+        LaunchSystem.RawLaunchArguments = args;
+
         try
         {
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/SaturnEdit/Systems/LaunchSystem.cs
+++ b/SaturnEdit/Systems/LaunchSystem.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SaturnEdit.Systems;
+
+public static class LaunchSystem
+{
+    public static void Initialize()
+    {
+        LaunchArguments = new LaunchArguments(RawLaunchArguments);
+    }
+
+    public static LaunchArguments LaunchArguments { get; private set; } = new([]);
+    public static string[] RawLaunchArguments
+    {
+        get => rawLaunchArguments;
+        set
+        {
+            if (rawLaunchArguments != null) throw new InvalidOperationException("Launch arguments have already been initialized.");
+
+            rawLaunchArguments = value;
+        }
+    }
+    private static string[]? rawLaunchArguments;
+}
+
+public sealed class LaunchArguments
+{
+    public LaunchArguments(IEnumerable<string> args)
+    {
+        arguments = args.ToArray();
+    }
+
+    public string? this[int index]
+    {
+        get => index >= 0 && index < arguments.Length
+            ? arguments[index]
+            : null;
+    }
+
+    public string? this[string argument]
+    {
+        get
+        {
+            if (!argument.StartsWith("--")) return null;
+
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                if (!arguments[i].StartsWith("--")) continue;
+                if (!string.Equals(arguments[i], argument, StringComparison.OrdinalIgnoreCase)) continue;
+
+                return i + 1 < arguments.Length && !arguments[i + 1].StartsWith("--")
+                    ? arguments[i + 1]
+                    : null;
+            }
+
+            return null;
+        }
+    }
+
+    public bool Has(string argument)
+    {
+        if (!argument.StartsWith("--")) return false;
+
+        return arguments.Any(x =>
+            x.StartsWith("--") &&
+            string.Equals(x, argument, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public int Count => arguments.Length;
+
+    private readonly string[] arguments = [];
+}

--- a/SaturnEdit/Windows/Main/MainWindow.axaml.cs
+++ b/SaturnEdit/Windows/Main/MainWindow.axaml.cs
@@ -1,20 +1,22 @@
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
-using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
+using SaturnData.Notation.Serialization;
 using SaturnEdit.Systems;
 using SaturnEdit.Utilities;
 using SaturnEdit.Windows.Dialogs;
 using SaturnEdit.Windows.Dialogs.ModalDialog;
 using SaturnEdit.Windows.Dialogs.Search;
 using SaturnEdit.Windows.Dialogs.VolumeMixer;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace SaturnEdit;
 
@@ -450,7 +452,23 @@ public partial class MainWindow : Window
         UpdateTabs();
         UpdateSplash();
         UpdateUpdateButton();
-        
+
+        var pathArgument = LaunchSystem.LaunchArguments[0];
+        if (pathArgument != null)
+        {
+            var path = Path.GetFullPath(pathArgument);
+            if (File.Exists(path))
+            {
+
+                ChartFormatVersion chartFormatVersion = NotationSerializer.DetectFormatVersion(path);
+                if (chartFormatVersion != ChartFormatVersion.Unknown)
+                {
+                    ChartSystem.ReadChart(path, new());
+                    Splash.IsVisible = false;
+                }
+            }
+        }
+
         base.OnLoaded(e);
     }
     

--- a/SaturnEdit/Windows/Main/MainWindow.axaml.cs
+++ b/SaturnEdit/Windows/Main/MainWindow.axaml.cs
@@ -453,18 +453,21 @@ public partial class MainWindow : Window
         UpdateSplash();
         UpdateUpdateButton();
 
-        var pathArgument = LaunchSystem.LaunchArguments[0];
-        if (pathArgument != null)
+        if (LaunchSystem.LaunchArguments.Count > 0)
         {
-            var path = Path.GetFullPath(pathArgument);
-            if (File.Exists(path))
+            var pathArgument = LaunchSystem.LaunchArguments[0];
+            if (pathArgument != null)
             {
-
-                ChartFormatVersion chartFormatVersion = NotationSerializer.DetectFormatVersion(path);
-                if (chartFormatVersion != ChartFormatVersion.Unknown)
+                var path = Path.GetFullPath(pathArgument);
+                if (File.Exists(path))
                 {
-                    ChartSystem.ReadChart(path, new());
-                    Splash.IsVisible = false;
+
+                    ChartFormatVersion chartFormatVersion = NotationSerializer.DetectFormatVersion(path);
+                    if (chartFormatVersion != ChartFormatVersion.Unknown)
+                    {
+                        ChartSystem.ReadChart(path, new());
+                        Splash.IsVisible = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Launch Arguments
Allow launch arguments to be passed and parsed.
LaunchSystem will set its arguments from Program.Main as a property as to not call any methods as per the warning listed:
```
// Initialization code. Don't use any Avalonia, third-party APIs or any
// SynchronizationContext-reliant code before AppMain is called: things aren't initialized
// yet and stuff might break.
```

LaunchSystem by default will automatically check for arguments prefixing as `--`, but this will most likely want to be changed in the future if launch arguments are implemented with shorthand names.

## Automatic chart open
I have also implemented automatic chart opening by the first argument supplied to the executable; it checks for if it is a file and then it checks the chart version before attempting to open.

This feature is incredibly useful for Windows users as they can set their preferred application of `.sat` files and can potentially be automatically applied for the user within the app with registry edits. This allows for a much smoother and seamless process of opening chart files.

This is done via the Splash menu so please move it to an appropriate spot if necessary, I chose this spot as recents are already loaded from here.